### PR TITLE
Introduce generic iteration code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["encoding", "UTF-8", "unicode", "iterator"]
 categories = ["text-processing", "encoding", "internationalization"]
 
 [dependencies]
-icu_collections = { path = "../icu4x/components/collections", optional = true }
+icu_collections = { git = "https://github.com/hsivonen/icu4x", branch = "withtrie", optional = true }
 
 [features]
 icu_collections = ["dep:icu_collections"]

--- a/src/cptrie.rs
+++ b/src/cptrie.rs
@@ -14,14 +14,99 @@
 // See the Licenses for the specific language governing permissions and
 // limitations under the Licenses.
 
-use crate::in_inclusive_range8;
+use crate::generic::{GenericUtf8Iter, Utf8Action};
 use crate::Utf8CharIndicesWithTrie;
-use crate::UTF8_DATA;
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use icu_collections::codepointtrie::AbstractCodePointTrie;
 use icu_collections::codepointtrie::TrieValue;
 use icu_collections::codepointtrie::WithTrie;
+
+#[derive(Debug)]
+struct Utf8CharsWithTrieAction<'trie, T, V>
+where
+    V: TrieValue,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    trie: &'trie T,
+    phantom: PhantomData<V>,
+}
+
+impl<'trie, T, V> Clone for Utf8CharsWithTrieAction<'trie, T, V>
+where
+    V: TrieValue,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            trie: self.trie,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'trie, T, V> Utf8Action for Utf8CharsWithTrieAction<'trie, T, V>
+where
+    V: TrieValue,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    type Output = (char, V);
+
+    #[inline(always)]
+    unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `ascii` is a valid
+        // ASCII byte (range `00..=7F`).
+        (char::from(ascii), unsafe { self.trie.ascii(ascii) })
+    }
+
+    #[inline(always)]
+    unsafe fn handle_2_byte(&mut self, b1: u8, b2: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1` and `b2`
+        // form a valid 2-byte UTF-8 sequence.
+        let high_five = u32::from(b1) & 0b11_111;
+        let low_six = u32::from(b2) & 0b111_111;
+        // SAFETY: `high_five` and `low_six` conform to the
+        // precondition of `utf8_two_byte` by construction.
+        let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
+        let point = (high_five << 6) | low_six;
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (unsafe { char::from_u32_unchecked(point) }, v)
+    }
+
+    #[inline(always)]
+    unsafe fn handle_3_byte(&mut self, b1: u8, b2: u8, b3: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, and `b3`
+        // form a valid 3-byte UTF-8 sequence.
+        let high_ten = ((u32::from(b1) & 0b1111) << 6) | (u32::from(b2) & 0b111_111);
+        let low_six = u32::from(b3) & 0b111_111;
+        // SAFETY: `high_ten` and `low_six` conform to the
+        // precondition of `utf8_three_byte` by construction.
+        let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
+        let point = (high_ten << 6) | low_six;
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (unsafe { char::from_u32_unchecked(point) }, v)
+    }
+
+    #[inline(always)]
+    unsafe fn handle_4_byte(&mut self, b1: u8, b2: u8, b3: u8, b4: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, `b3`, and `b4`
+        // form a valid 4-byte UTF-8 sequence.
+        let point = ((u32::from(b1) & 0x7) << 18)
+            | ((u32::from(b2) & 0x3F) << 12)
+            | ((u32::from(b3) & 0x3F) << 6)
+            | (u32::from(b4) & 0x3F);
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (
+            unsafe { char::from_u32_unchecked(point) },
+            self.trie.supplementary(point),
+        )
+    }
+
+    #[inline(always)]
+    fn handle_error(&mut self) -> Self::Output {
+        ('\u{FFFD}', self.trie.bmp(0xFFFD))
+    }
+}
 
 /// Iterator by `char` and `icu_collections::codepointtrie::TrieValue`
 /// over `&[u8]` that contains potentially-invalid UTF-8. See the
@@ -32,9 +117,19 @@ where
     V: TrieValue,
     T: AbstractCodePointTrie<'trie, V>,
 {
-    remaining: &'slice [u8],
-    trie: &'trie T,
-    phantom: PhantomData<V>,
+    inner: GenericUtf8Iter<'slice, Utf8CharsWithTrieAction<'trie, T, V>>,
+}
+
+impl<'slice, 'trie, T, V> Clone for Utf8CharsWithTrie<'slice, 'trie, T, V>
+where
+    V: TrieValue,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<'slice, 'trie, T, V> Utf8CharsWithTrie<'slice, 'trie, T, V>
@@ -46,9 +141,13 @@ where
     /// Creates the iterator from a byte slice.
     pub fn new(bytes: &'slice [u8], trie: &'trie T) -> Self {
         Self {
-            remaining: bytes,
-            trie,
-            phantom: PhantomData,
+            inner: GenericUtf8Iter::new(
+                bytes,
+                Utf8CharsWithTrieAction {
+                    trie,
+                    phantom: PhantomData,
+                },
+            ),
         }
     }
 
@@ -56,93 +155,7 @@ where
     /// of the original slice.
     #[inline(always)]
     pub fn as_slice(&self) -> &'slice [u8] {
-        self.remaining
-    }
-
-    #[inline(never)]
-    fn next_fallback(&mut self) -> Option<(char, V)> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let first = self.remaining[0];
-        if first < 0x80 {
-            self.remaining = &self.remaining[1..];
-            // SAFETY: We just checked the precondition of `ascii()` above.
-            return Some((char::from(first), unsafe { self.trie.ascii(first) }));
-        }
-        if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
-            self.remaining = &self.remaining[1..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        let second = self.remaining[1];
-        let (lower_bound, upper_bound) = match first {
-            0xE0 => (0xA0, 0xBF),
-            0xED => (0x80, 0x9F),
-            0xF0 => (0x90, 0xBF),
-            0xF4 => (0x80, 0x8F),
-            _ => (0x80, 0xBF),
-        };
-        if !in_inclusive_range8(second, lower_bound, upper_bound) {
-            self.remaining = &self.remaining[1..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        if first < 0xE0 {
-            self.remaining = &self.remaining[2..];
-            let high_five = u32::from(first) & 0b11_111;
-            let low_six = u32::from(second) & 0b111_111;
-            // SAFETY: `high_five` and `low_six` conform to the
-            // precondition of `utf8_two_byte` by construction.
-            let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
-            let point = (high_five << 6) | low_six;
-            // SAFETY: `point` is in the scalar value range, because
-            // we've checked that `first` is a valid lead byte and
-            // we've then masked five bits from `first` and six bits
-            // from `second`.
-            return Some((unsafe { char::from_u32_unchecked(point) }, v));
-        }
-        if self.remaining.len() == 2 {
-            self.remaining = &self.remaining[2..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        let third = self.remaining[2];
-        if !in_inclusive_range8(third, 0x80, 0xBF) {
-            self.remaining = &self.remaining[2..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        if first < 0xF0 {
-            self.remaining = &self.remaining[3..];
-            let high_ten = ((u32::from(first) & 0b1111) << 6) | (u32::from(second) & 0b111_111);
-            let low_six = u32::from(third) & 0b111_111;
-            // SAFETY: `high_ten` and `low_six` conform to the
-            // precondition of `utf8_three_byte` by construction.
-            let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
-            let point = (high_ten << 6) | low_six;
-            // SAFETY: `point` is in the scalar value range, because
-            // we've checked that `first` is a valid lead byte and
-            // we've then masked four bits from `first` and six bits
-            // from both `second` and `third`.
-            return Some((unsafe { char::from_u32_unchecked(point) }, v));
-        }
-        // At this point, we have a valid 3-byte prefix of a
-        // four-byte sequence that has to be incomplete, because
-        // otherwise `next()` would have succeeded.
-        self.remaining = &self.remaining[3..];
-        Some(('\u{FFFD}', self.trie.bmp(0xFFFD)))
-    }
-}
-
-impl<'slice, 'trie, T, V> Clone for Utf8CharsWithTrie<'slice, 'trie, T, V>
-where
-    V: TrieValue,
-    T: AbstractCodePointTrie<'trie, V>,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            remaining: self.remaining,
-            trie: self.trie,
-            phantom: PhantomData,
-        }
+        self.inner.as_slice()
     }
 }
 
@@ -153,7 +166,7 @@ where
 {
     #[inline]
     fn trie(&self) -> &'trie T {
-        self.trie
+        self.inner.action.trie
     }
 }
 
@@ -164,84 +177,9 @@ where
 {
     type Item = (char, V);
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        // This loop is only broken out of as goto forward
-        #[allow(clippy::never_loop)]
-        loop {
-            if self.remaining.len() < 4 {
-                break;
-            }
-            let first = self.remaining[0];
-            if first < 0x80 {
-                self.remaining = &self.remaining[1..];
-                // SAFETY: We just checked the precondition of `ascii()` above.
-                return Some((char::from(first), unsafe { self.trie.ascii(first) }));
-            }
-            let second = self.remaining[1];
-            if in_inclusive_range8(first, 0xC2, 0xDF) {
-                if !in_inclusive_range8(second, 0x80, 0xBF) {
-                    break;
-                }
-                self.remaining = &self.remaining[2..];
-                let high_five = u32::from(first) & 0b11_111;
-                let low_six = u32::from(second) & 0b111_111;
-                // SAFETY: `high_five` and `low_six` conform to the
-                // precondition of `utf8_two_byte` by construction.
-                let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
-                let point = (high_five << 6) | low_six;
-                // SAFETY: `point` is in the scalar value range, because
-                // we've checked that `first` is a valid lead byte and
-                // we've then masked five bits from `first` and six bits
-                // from `second`.
-                return Some((unsafe { char::from_u32_unchecked(point) }, v));
-            }
-            // This table-based formulation was benchmark-based in encoding_rs,
-            // but it hasn't been re-benchmarked in this iterator context.
-            let third = self.remaining[2];
-            if first < 0xF0 {
-                if ((UTF8_DATA.table[usize::from(second)]
-                    & UTF8_DATA.table[usize::from(first) + 0x80])
-                    | (third >> 6))
-                    != 2
-                {
-                    break;
-                }
-                self.remaining = &self.remaining[3..];
-                let high_ten = ((u32::from(first) & 0b1111) << 6) | (u32::from(second) & 0b111_111);
-                let low_six = u32::from(third) & 0b111_111;
-                // SAFETY: `high_ten` and `low_six` conform to the
-                // precondition of `utf8_three_byte` by construction.
-                let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
-                let point = (high_ten << 6) | low_six;
-                // SAFETY: `point` is in the scalar value range, because
-                // we've checked that `first` is a valid lead byte and
-                // we've then masked four bits from `first` and six bits
-                // from both `second` and `third`.
-                return Some((unsafe { char::from_u32_unchecked(point) }, v));
-            }
-            let fourth = self.remaining[3];
-            if (u16::from(
-                UTF8_DATA.table[usize::from(second)] & UTF8_DATA.table[usize::from(first) + 0x80],
-            ) | u16::from(third >> 6)
-                | (u16::from(fourth & 0xC0) << 2))
-                != 0x202
-            {
-                break;
-            }
-            let point = ((u32::from(first) & 0x7) << 18)
-                | ((u32::from(second) & 0x3F) << 12)
-                | ((u32::from(third) & 0x3F) << 6)
-                | (u32::from(fourth) & 0x3F);
-            self.remaining = &self.remaining[4..];
-            // SAFETY: We've validated that `first` is a valid four-byte lead,
-            // taken 3 low bits from it, and six low bits from each trail.
-            return Some((
-                unsafe { char::from_u32_unchecked(point) },
-                self.trie.supplementary(point),
-            ));
-        }
-        self.next_fallback()
+        self.inner.next()
     }
 }
 
@@ -250,31 +188,9 @@ where
     V: TrieValue,
     T: AbstractCodePointTrie<'trie, V>,
 {
-    #[inline]
-    fn next_back(&mut self) -> Option<(char, V)> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let mut attempt = 1;
-        for b in self.remaining.iter().rev() {
-            if b & 0xC0 != 0x80 {
-                let (head, tail) = self.remaining.split_at(self.remaining.len() - attempt);
-                let mut inner = Utf8CharsWithTrie::new(tail, self.trie);
-                let candidate = inner.next();
-                if inner.as_slice().is_empty() {
-                    self.remaining = head;
-                    return candidate;
-                }
-                break;
-            }
-            if attempt == 4 {
-                break;
-            }
-            attempt += 1;
-        }
-
-        self.remaining = &self.remaining[..self.remaining.len() - 1];
-        Some(('\u{FFFD}', self.trie.bmp(0xFFFD)))
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
     }
 }
 
@@ -329,6 +245,92 @@ where
 
 // --
 
+#[derive(Debug)]
+struct Utf8CharsWithTrieDefaultForAsciiAction<'trie, T, V>
+where
+    V: TrieValue + Default,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    trie: &'trie T,
+    phantom: PhantomData<V>,
+}
+
+impl<'trie, T, V> Clone for Utf8CharsWithTrieDefaultForAsciiAction<'trie, T, V>
+where
+    V: TrieValue + Default,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            trie: self.trie,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'trie, T, V> Utf8Action for Utf8CharsWithTrieDefaultForAsciiAction<'trie, T, V>
+where
+    V: TrieValue + Default,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    type Output = (char, V);
+
+    #[inline(always)]
+    unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `ascii` is a valid
+        // ASCII byte (range `00..=7F`).
+        (char::from(ascii), V::default())
+    }
+
+    #[inline(always)]
+    unsafe fn handle_2_byte(&mut self, b1: u8, b2: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1` and `b2`
+        // form a valid 2-byte UTF-8 sequence.
+        let high_five = u32::from(b1) & 0b11_111;
+        let low_six = u32::from(b2) & 0b111_111;
+        // SAFETY: `high_five` and `low_six` conform to the
+        // precondition of `utf8_two_byte` by construction.
+        let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
+        let point = (high_five << 6) | low_six;
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (unsafe { char::from_u32_unchecked(point) }, v)
+    }
+
+    #[inline(always)]
+    unsafe fn handle_3_byte(&mut self, b1: u8, b2: u8, b3: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, and `b3`
+        // form a valid 3-byte UTF-8 sequence.
+        let high_ten = ((u32::from(b1) & 0b1111) << 6) | (u32::from(b2) & 0b111_111);
+        let low_six = u32::from(b3) & 0b111_111;
+        // SAFETY: `high_ten` and `low_six` conform to the
+        // precondition of `utf8_three_byte` by construction.
+        let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
+        let point = (high_ten << 6) | low_six;
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (unsafe { char::from_u32_unchecked(point) }, v)
+    }
+
+    #[inline(always)]
+    unsafe fn handle_4_byte(&mut self, b1: u8, b2: u8, b3: u8, b4: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, `b3`, and `b4`
+        // form a valid 4-byte UTF-8 sequence.
+        let point = ((u32::from(b1) & 0x7) << 18)
+            | ((u32::from(b2) & 0x3F) << 12)
+            | ((u32::from(b3) & 0x3F) << 6)
+            | (u32::from(b4) & 0x3F);
+        // SAFETY: The resulting `point` is a valid code point by the trait contract.
+        (
+            unsafe { char::from_u32_unchecked(point) },
+            self.trie.supplementary(point),
+        )
+    }
+
+    #[inline(always)]
+    fn handle_error(&mut self) -> Self::Output {
+        ('\u{FFFD}', self.trie.bmp(0xFFFD))
+    }
+}
+
 /// Iterator by `char` and `icu_collections::codepointtrie::TrieValue`
 /// over `&[u8]` that contains potentially-invalid UTF-8. Uses `V::default()`
 /// for ASCII instead of reading from the trie. See the
@@ -339,9 +341,19 @@ where
     V: TrieValue + Default,
     T: AbstractCodePointTrie<'trie, V>,
 {
-    remaining: &'slice [u8],
-    trie: &'trie T,
-    phantom: PhantomData<V>,
+    inner: GenericUtf8Iter<'slice, Utf8CharsWithTrieDefaultForAsciiAction<'trie, T, V>>,
+}
+
+impl<'slice, 'trie, T, V> Clone for Utf8CharsWithTrieDefaultForAscii<'slice, 'trie, T, V>
+where
+    V: TrieValue + Default,
+    T: AbstractCodePointTrie<'trie, V>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<'slice, 'trie, T, V> Utf8CharsWithTrieDefaultForAscii<'slice, 'trie, T, V>
@@ -353,9 +365,13 @@ where
     /// Creates the iterator from a byte slice.
     pub fn new(bytes: &'slice [u8], trie: &'trie T) -> Self {
         Self {
-            remaining: bytes,
-            trie,
-            phantom: PhantomData,
+            inner: GenericUtf8Iter::new(
+                bytes,
+                Utf8CharsWithTrieDefaultForAsciiAction {
+                    trie,
+                    phantom: PhantomData,
+                },
+            ),
         }
     }
 
@@ -363,92 +379,7 @@ where
     /// of the original slice.
     #[inline(always)]
     pub fn as_slice(&self) -> &'slice [u8] {
-        self.remaining
-    }
-
-    #[inline(never)]
-    fn next_fallback(&mut self) -> Option<(char, V)> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let first = self.remaining[0];
-        if first < 0x80 {
-            self.remaining = &self.remaining[1..];
-            return Some((char::from(first), V::default()));
-        }
-        if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
-            self.remaining = &self.remaining[1..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        let second = self.remaining[1];
-        let (lower_bound, upper_bound) = match first {
-            0xE0 => (0xA0, 0xBF),
-            0xED => (0x80, 0x9F),
-            0xF0 => (0x90, 0xBF),
-            0xF4 => (0x80, 0x8F),
-            _ => (0x80, 0xBF),
-        };
-        if !in_inclusive_range8(second, lower_bound, upper_bound) {
-            self.remaining = &self.remaining[1..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        if first < 0xE0 {
-            self.remaining = &self.remaining[2..];
-            let high_five = u32::from(first) & 0b11_111;
-            let low_six = u32::from(second) & 0b111_111;
-            // SAFETY: `high_five` and `low_six` conform to the
-            // precondition of `utf8_two_byte` by construction.
-            let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
-            let point = (high_five << 6) | low_six;
-            // SAFETY: `point` is in the scalar value range, because
-            // we've checked that `first` is a valid lead byte and
-            // we've then masked five bits from `first` and six bits
-            // from `second`.
-            return Some((unsafe { char::from_u32_unchecked(point) }, v));
-        }
-        if self.remaining.len() == 2 {
-            self.remaining = &self.remaining[2..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        let third = self.remaining[2];
-        if !in_inclusive_range8(third, 0x80, 0xBF) {
-            self.remaining = &self.remaining[2..];
-            return Some(('\u{FFFD}', self.trie.bmp(0xFFFD)));
-        }
-        if first < 0xF0 {
-            self.remaining = &self.remaining[3..];
-            let high_ten = ((u32::from(first) & 0b1111) << 6) | (u32::from(second) & 0b111_111);
-            let low_six = u32::from(third) & 0b111_111;
-            // SAFETY: `high_ten` and `low_six` conform to the
-            // precondition of `utf8_three_byte` by construction.
-            let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
-            let point = (high_ten << 6) | low_six;
-            // SAFETY: `point` is in the scalar value range, because
-            // we've checked that `first` is a valid lead byte and
-            // we've then masked four bits from `first` and six bits
-            // from both `second` and `third`.
-            return Some((unsafe { char::from_u32_unchecked(point) }, v));
-        }
-        // At this point, we have a valid 3-byte prefix of a
-        // four-byte sequence that has to be incomplete, because
-        // otherwise `next()` would have succeeded.
-        self.remaining = &self.remaining[3..];
-        Some(('\u{FFFD}', self.trie.bmp(0xFFFD)))
-    }
-}
-
-impl<'slice, 'trie, T, V> Clone for Utf8CharsWithTrieDefaultForAscii<'slice, 'trie, T, V>
-where
-    V: TrieValue + Default,
-    T: AbstractCodePointTrie<'trie, V>,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            remaining: self.remaining,
-            trie: self.trie,
-            phantom: PhantomData,
-        }
+        self.inner.as_slice()
     }
 }
 
@@ -460,7 +391,7 @@ where
 {
     #[inline]
     fn trie(&self) -> &'trie T {
-        self.trie
+        self.inner.action.trie
     }
 }
 
@@ -471,83 +402,9 @@ where
 {
     type Item = (char, V);
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        // This loop is only broken out of as goto forward
-        #[allow(clippy::never_loop)]
-        loop {
-            if self.remaining.len() < 4 {
-                break;
-            }
-            let first = self.remaining[0];
-            if first < 0x80 {
-                self.remaining = &self.remaining[1..];
-                return Some((char::from(first), V::default()));
-            }
-            let second = self.remaining[1];
-            if in_inclusive_range8(first, 0xC2, 0xDF) {
-                if !in_inclusive_range8(second, 0x80, 0xBF) {
-                    break;
-                }
-                self.remaining = &self.remaining[2..];
-                let high_five = u32::from(first) & 0b11_111;
-                let low_six = u32::from(second) & 0b111_111;
-                // SAFETY: `high_five` and `low_six` conform to the
-                // precondition of `utf8_two_byte` by construction.
-                let v = unsafe { self.trie.utf8_two_byte(high_five, low_six) };
-                let point = (high_five << 6) | low_six;
-                // SAFETY: `point` is in the scalar value range, because
-                // we've checked that `first` is a valid lead byte and
-                // we've then masked five bits from `first` and six bits
-                // from `second`.
-                return Some((unsafe { char::from_u32_unchecked(point) }, v));
-            }
-            // This table-based formulation was benchmark-based in encoding_rs,
-            // but it hasn't been re-benchmarked in this iterator context.
-            let third = self.remaining[2];
-            if first < 0xF0 {
-                if ((UTF8_DATA.table[usize::from(second)]
-                    & UTF8_DATA.table[usize::from(first) + 0x80])
-                    | (third >> 6))
-                    != 2
-                {
-                    break;
-                }
-                self.remaining = &self.remaining[3..];
-                let high_ten = ((u32::from(first) & 0b1111) << 6) | (u32::from(second) & 0b111_111);
-                let low_six = u32::from(third) & 0b111_111;
-                // SAFETY: `high_ten` and `low_six` conform to the
-                // precondition of `utf8_three_byte` by construction.
-                let v = unsafe { self.trie.utf8_three_byte(high_ten, low_six) };
-                let point = (high_ten << 6) | low_six;
-                // SAFETY: `point` is in the scalar value range, because
-                // we've checked that `first` is a valid lead byte and
-                // we've then masked four bits from `first` and six bits
-                // from both `second` and `third`.
-                return Some((unsafe { char::from_u32_unchecked(point) }, v));
-            }
-            let fourth = self.remaining[3];
-            if (u16::from(
-                UTF8_DATA.table[usize::from(second)] & UTF8_DATA.table[usize::from(first) + 0x80],
-            ) | u16::from(third >> 6)
-                | (u16::from(fourth & 0xC0) << 2))
-                != 0x202
-            {
-                break;
-            }
-            let point = ((u32::from(first) & 0x7) << 18)
-                | ((u32::from(second) & 0x3F) << 12)
-                | ((u32::from(third) & 0x3F) << 6)
-                | (u32::from(fourth) & 0x3F);
-            self.remaining = &self.remaining[4..];
-            // SAFETY: We've validated that `first` is a valid four-byte lead,
-            // taken 3 low bits from it, and six low bits from each trail.
-            return Some((
-                unsafe { char::from_u32_unchecked(point) },
-                self.trie.supplementary(point),
-            ));
-        }
-        self.next_fallback()
+        self.inner.next()
     }
 }
 
@@ -557,31 +414,9 @@ where
     V: TrieValue + Default,
     T: AbstractCodePointTrie<'trie, V>,
 {
-    #[inline]
-    fn next_back(&mut self) -> Option<(char, V)> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let mut attempt = 1;
-        for b in self.remaining.iter().rev() {
-            if b & 0xC0 != 0x80 {
-                let (head, tail) = self.remaining.split_at(self.remaining.len() - attempt);
-                let mut inner = Utf8CharsWithTrieDefaultForAscii::new(tail, self.trie);
-                let candidate = inner.next();
-                if inner.as_slice().is_empty() {
-                    self.remaining = head;
-                    return candidate;
-                }
-                break;
-            }
-            if attempt == 4 {
-                break;
-            }
-            attempt += 1;
-        }
-
-        self.remaining = &self.remaining[..self.remaining.len() - 1];
-        Some(('\u{FFFD}', self.trie.bmp(0xFFFD)))
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
     }
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,250 @@
+use crate::{in_inclusive_range8, UTF8_DATA};
+
+/// A trait that defines the behavior for handling different UTF-8 sequence lengths
+/// for use in [`GenericUtf8Iter`].
+///
+/// Implementors of this trait can be used with `GenericUtf8Iter` to decode UTF-8 bytes
+/// and produce different outputs (e.g., `char`, `Result<char, Error>`, `(char, TrieValue)`).
+///
+/// # Safety
+///
+/// While this trait is not marked `unsafe`, its methods are called by `GenericUtf8Iter`
+/// with the guarantee that the input bytes or decoded scalar values are valid UTF-8.
+/// Implementors may choose to rely on this guarantee for performance (e.g., by using
+/// `core::char::from_u32_unchecked`), but doing so requires an `unsafe` block within the
+/// implementation.
+pub trait Utf8Action {
+    /// The type of item yielded by the iterator.
+    type Output;
+
+    /// Called when a valid ASCII byte (0-127) is encountered.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ascii` is in the range `00..=7F`.
+    unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output;
+
+    /// Called when a valid 2-byte UTF-8 sequence is encountered.
+    ///
+    /// Precise byte range: `C2..=DF` followed by `80..=BF`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `point` is a valid 2-byte UTF-8 sequence
+    /// (scalar values in the range `U+0080..=U+07FF`).
+    unsafe fn handle_2_byte(&mut self, point: u32) -> Self::Output;
+
+    /// Called when a valid 3-byte UTF-8 sequence is encountered.
+    ///
+    /// Precise byte range:
+    /// - `E0` followed by `A0..=BF`, `80..=BF`
+    /// - `E1..=EC` followed by `80..=BF`, `80..=BF`
+    /// - `ED` followed by `80..=9F`, `80..=BF`
+    /// - `EE..=EF` followed by `80..=BF`, `80..=BF`
+    ///
+    /// A different way of looking at this is `E0 A0 BF` to `EF BF BF`
+    /// with continuation bytes always staying in the range `80..=BF`,
+    /// removing the surrogates in `ED A0 80` to `ED BF BF`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `point` is a valid 3-byte UTF-8 sequence
+    /// (scalar values in the range `U+0800..=U+FFFF`,
+    /// excluding surrogates `U+D800..=U+DFFF`).
+    unsafe fn handle_3_byte(&mut self, point: u32) -> Self::Output;
+
+    /// Called when a valid 4-byte UTF-8 sequence is encountered.
+    ///
+    /// Precise byte range:
+    /// - `F0` followed by `90..=BF`, `80..=BF`, `80..=BF`
+    /// - `F1..=F3` followed by `80..=BF`, `80..=BF`, `80..=BF`
+    /// - `F4` followed by `80..=8F`, `80..=BF`, `80..=BF`
+    ///
+    /// A different way of looking at this is `F0 90 80 80` to `F4 8F BF BF`
+    /// with continuation bytes always staying in the range `80..=BF`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `point` is a valid 2-byte UTF-8 sequence
+    /// (scalar values in the range `U+0080..=U+07FF`).
+    unsafe fn handle_4_byte(&mut self, point: u32) -> Self::Output;
+
+    /// Called when an invalid sequence (error) is encountered.
+    ///
+    /// The `GenericUtf8Iter` automatically steps over the invalid bytes before calling this.
+    fn handle_error(&mut self) -> Self::Output;
+
+    /// Called when an invalid sequence (error) is encountered while iterating backwards.
+    fn handle_error_reverse(&mut self) -> Self::Output {
+        self.handle_error()
+    }
+}
+/// A generic UTF-8 iterator that delegates to a `Utf8Action`.
+pub struct GenericUtf8Iter<'a, A> {
+    pub(crate) remaining: &'a [u8],
+    pub(crate) action: A,
+}
+
+impl<'a, A: Utf8Action> GenericUtf8Iter<'a, A> {
+    #[inline(always)]
+    pub fn new(remaining: &'a [u8], action: A) -> Self {
+        Self { remaining, action }
+    }
+
+    #[inline(always)]
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.remaining
+    }
+
+    #[inline(never)]
+    fn next_fallback(&mut self) -> Option<A::Output> {
+        if self.remaining.is_empty() {
+            return None;
+        }
+        let first = self.remaining[0];
+        if first < 0x80 {
+            self.remaining = &self.remaining[1..];
+            // SAFETY: `first` was just checked to be `< 0x80`.
+            return Some(unsafe { self.action.handle_ascii(first) });
+        }
+        if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
+            self.remaining = &self.remaining[1..];
+            return Some(self.action.handle_error());
+        }
+        let second = self.remaining[1];
+        let (lower_bound, upper_bound) = match first {
+            0xE0 => (0xA0, 0xBF),
+            0xED => (0x80, 0x9F),
+            0xF0 => (0x90, 0xBF),
+            0xF4 => (0x80, 0x8F),
+            _ => (0x80, 0xBF),
+        };
+        if !in_inclusive_range8(second, lower_bound, upper_bound) {
+            self.remaining = &self.remaining[1..];
+            return Some(self.action.handle_error());
+        }
+        if first < 0xE0 {
+            self.remaining = &self.remaining[2..];
+            let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
+            // SAFETY: `first` and `second` have been validated to form a correct 2-byte sequence.
+            return Some(unsafe { self.action.handle_2_byte(point) });
+        }
+        if self.remaining.len() == 2 {
+            self.remaining = &self.remaining[2..];
+            return Some(self.action.handle_error());
+        }
+        let third = self.remaining[2];
+        if !in_inclusive_range8(third, 0x80, 0xBF) {
+            self.remaining = &self.remaining[2..];
+            return Some(self.action.handle_error());
+        }
+        if first < 0xF0 {
+            self.remaining = &self.remaining[3..];
+            let point = ((u32::from(first) & 0xF) << 12)
+                | ((u32::from(second) & 0x3F) << 6)
+                | (u32::from(third) & 0x3F);
+            // SAFETY: `first`, `second`, and `third` have been validated to form a correct 3-byte sequence.
+            return Some(unsafe { self.action.handle_3_byte(point) });
+        }
+        // At this point, we have a valid 3-byte prefix of a
+        // four-byte sequence that has to be incomplete.
+        self.remaining = &self.remaining[3..];
+        Some(self.action.handle_error())
+    }
+}
+
+impl<'a, A: Utf8Action> Iterator for GenericUtf8Iter<'a, A> {
+    type Item = A::Output;
+
+    #[inline]
+    fn next(&mut self) -> Option<A::Output> {
+        #[allow(clippy::never_loop)]
+        loop {
+            if self.remaining.len() < 4 {
+                break;
+            }
+            let first = self.remaining[0];
+            if first < 0x80 {
+                self.remaining = &self.remaining[1..];
+                // SAFETY: `first` was just checked to be `< 0x80`.
+                return Some(unsafe { self.action.handle_ascii(first) });
+            }
+            let second = self.remaining[1];
+            if in_inclusive_range8(first, 0xC2, 0xDF) {
+                if !in_inclusive_range8(second, 0x80, 0xBF) {
+                    break;
+                }
+                let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
+                self.remaining = &self.remaining[2..];
+                // SAFETY: `first` and `second` have been validated to form a correct 2-byte sequence.
+                return Some(unsafe { self.action.handle_2_byte(point) });
+            }
+            let third = self.remaining[2];
+            if first < 0xF0 {
+                if ((UTF8_DATA.table[usize::from(second)]
+                    & UTF8_DATA.table[usize::from(first) + 0x80])
+                    | (third >> 6))
+                    != 2
+                {
+                    break;
+                }
+                let point = ((u32::from(first) & 0xF) << 12)
+                    | ((u32::from(second) & 0x3F) << 6)
+                    | (u32::from(third) & 0x3F);
+                self.remaining = &self.remaining[3..];
+                // SAFETY: `first`, `second`, and `third` have been validated to form a correct 3-byte sequence.
+                return Some(unsafe { self.action.handle_3_byte(point) });
+            }
+            let fourth = self.remaining[3];
+            if (u16::from(
+                UTF8_DATA.table[usize::from(second)] & UTF8_DATA.table[usize::from(first) + 0x80],
+            ) | u16::from(third >> 6)
+                | (u16::from(fourth & 0xC0) << 2))
+                != 0x202
+            {
+                break;
+            }
+            let point = ((u32::from(first) & 0x7) << 18)
+                | ((u32::from(second) & 0x3F) << 12)
+                | ((u32::from(third) & 0x3F) << 6)
+                | (u32::from(fourth) & 0x3F);
+            self.remaining = &self.remaining[4..];
+            // SAFETY: `first`, `second`, `third`, and `fourth` have been validated to form a correct 4-byte sequence.
+            return Some(unsafe { self.action.handle_4_byte(point) });
+        }
+        self.next_fallback()
+    }
+}
+
+// In order for `DoubleEndedIterator` to be implemented via `GenericUtf8Iter`'s 
+// `next_back`, `A` must implement `Clone` because the back iteration relies 
+// on repeatedly instantiating a temporary inner iterator and consuming it.
+impl<'a, A: Utf8Action + Clone> DoubleEndedIterator for GenericUtf8Iter<'a, A> {
+    #[inline]
+    fn next_back(&mut self) -> Option<A::Output> {
+        if self.remaining.is_empty() {
+            return None;
+        }
+        let mut attempt = 1;
+        for b in self.remaining.iter().rev() {
+            if b & 0xC0 != 0x80 {
+                let (head, tail) = self.remaining.split_at(self.remaining.len() - attempt);
+                // Important: we pass a clone of the action.
+                let mut inner = GenericUtf8Iter::new(tail, self.action.clone());
+                let candidate = inner.next();
+                if inner.as_slice().is_empty() {
+                    self.remaining = head;
+                    return candidate;
+                }
+                break;
+            }
+            if attempt == 4 {
+                break;
+            }
+            attempt += 1;
+        }
+
+        self.remaining = &self.remaining[..self.remaining.len() - 1];
+        Some(self.action.handle_error_reverse())
+    }
+}

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -21,7 +21,7 @@ pub trait Utf8Action {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `ascii` is in the range `00..=7F`.
+    /// The byte is guaranteed to be in the range `00..=7F`.
     unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output;
 
     /// Called when a valid 2-byte UTF-8 sequence is encountered.
@@ -30,9 +30,8 @@ pub trait Utf8Action {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `point` is a valid 2-byte UTF-8 sequence
-    /// (scalar values in the range `U+0080..=U+07FF`).
-    unsafe fn handle_2_byte(&mut self, point: u32) -> Self::Output;
+    /// The caller must ensure that `b1` and `b2` form a valid 2-byte UTF-8 sequence.
+    unsafe fn handle_2_byte(&mut self, b1: u8, b2: u8) -> Self::Output;
 
     /// Called when a valid 3-byte UTF-8 sequence is encountered.
     ///
@@ -42,16 +41,10 @@ pub trait Utf8Action {
     /// - `ED` followed by `80..=9F`, `80..=BF`
     /// - `EE..=EF` followed by `80..=BF`, `80..=BF`
     ///
-    /// A different way of looking at this is `E0 A0 BF` to `EF BF BF`
-    /// with continuation bytes always staying in the range `80..=BF`,
-    /// removing the surrogates in `ED A0 80` to `ED BF BF`.
-    ///
     /// # Safety
     ///
-    /// The caller must ensure `point` is a valid 3-byte UTF-8 sequence
-    /// (scalar values in the range `U+0800..=U+FFFF`,
-    /// excluding surrogates `U+D800..=U+DFFF`).
-    unsafe fn handle_3_byte(&mut self, point: u32) -> Self::Output;
+    /// The caller must ensure that `b1`, `b2`, and `b3` form a valid 3-byte UTF-8 sequence.
+    unsafe fn handle_3_byte(&mut self, b1: u8, b2: u8, b3: u8) -> Self::Output;
 
     /// Called when a valid 4-byte UTF-8 sequence is encountered.
     ///
@@ -60,14 +53,10 @@ pub trait Utf8Action {
     /// - `F1..=F3` followed by `80..=BF`, `80..=BF`, `80..=BF`
     /// - `F4` followed by `80..=8F`, `80..=BF`, `80..=BF`
     ///
-    /// A different way of looking at this is `F0 90 80 80` to `F4 8F BF BF`
-    /// with continuation bytes always staying in the range `80..=BF`.
-    ///
     /// # Safety
     ///
-    /// The caller must ensure `point` is a valid 2-byte UTF-8 sequence
-    /// (scalar values in the range `U+0080..=U+07FF`).
-    unsafe fn handle_4_byte(&mut self, point: u32) -> Self::Output;
+    /// The caller must ensure that `b1`, `b2`, `b3`, and `b4` form a valid 4-byte UTF-8 sequence.
+    unsafe fn handle_4_byte(&mut self, b1: u8, b2: u8, b3: u8, b4: u8) -> Self::Output;
 
     /// Called when an invalid sequence (error) is encountered.
     ///
@@ -79,7 +68,9 @@ pub trait Utf8Action {
         self.handle_error()
     }
 }
+
 /// A generic UTF-8 iterator that delegates to a `Utf8Action`.
+#[derive(Debug, Clone)]
 pub struct GenericUtf8Iter<'a, A> {
     pub(crate) remaining: &'a [u8],
     pub(crate) action: A,
@@ -104,7 +95,7 @@ impl<'a, A: Utf8Action> GenericUtf8Iter<'a, A> {
         let first = self.remaining[0];
         if first < 0x80 {
             self.remaining = &self.remaining[1..];
-            // SAFETY: `first` was just checked to be `< 0x80`.
+            // SAFETY: `first` was just checked to be `< 0x80`, which is the range for ASCII.
             return Some(unsafe { self.action.handle_ascii(first) });
         }
         if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
@@ -125,9 +116,11 @@ impl<'a, A: Utf8Action> GenericUtf8Iter<'a, A> {
         }
         if first < 0xE0 {
             self.remaining = &self.remaining[2..];
-            let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
-            // SAFETY: `first` and `second` have been validated to form a correct 2-byte sequence.
-            return Some(unsafe { self.action.handle_2_byte(point) });
+            // SAFETY: `first` is in `C2..=DF` (due to the `in_inclusive_range8(first, 0xC2, 0xF4)`
+            // check above and the `first < 0xE0` check here) and `second` is in `80..=BF`
+            // (due to the `match first` and `in_inclusive_range8(second, lower_bound, upper_bound)`
+            // checks above), which together form a valid 2-byte UTF-8 sequence.
+            return Some(unsafe { self.action.handle_2_byte(first, second) });
         }
         if self.remaining.len() == 2 {
             self.remaining = &self.remaining[2..];
@@ -140,11 +133,11 @@ impl<'a, A: Utf8Action> GenericUtf8Iter<'a, A> {
         }
         if first < 0xF0 {
             self.remaining = &self.remaining[3..];
-            let point = ((u32::from(first) & 0xF) << 12)
-                | ((u32::from(second) & 0x3F) << 6)
-                | (u32::from(third) & 0x3F);
-            // SAFETY: `first`, `second`, and `third` have been validated to form a correct 3-byte sequence.
-            return Some(unsafe { self.action.handle_3_byte(point) });
+            // SAFETY: `first` is in `E0..=EF` (due to the `first < 0xE0` check failure and the
+            // `first < 0xF0` check here), `second` has been validated against `lower_bound`
+            // and `upper_bound` for this lead byte, and `third` is in `80..=BF`. Together
+            // these form a valid 3-byte UTF-8 sequence.
+            return Some(unsafe { self.action.handle_3_byte(first, second, third) });
         }
         // At this point, we have a valid 3-byte prefix of a
         // four-byte sequence that has to be incomplete.
@@ -166,7 +159,7 @@ impl<'a, A: Utf8Action> Iterator for GenericUtf8Iter<'a, A> {
             let first = self.remaining[0];
             if first < 0x80 {
                 self.remaining = &self.remaining[1..];
-                // SAFETY: `first` was just checked to be `< 0x80`.
+                // SAFETY: `first` was just checked to be `< 0x80`, which is the range for ASCII.
                 return Some(unsafe { self.action.handle_ascii(first) });
             }
             let second = self.remaining[1];
@@ -174,10 +167,10 @@ impl<'a, A: Utf8Action> Iterator for GenericUtf8Iter<'a, A> {
                 if !in_inclusive_range8(second, 0x80, 0xBF) {
                     break;
                 }
-                let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
                 self.remaining = &self.remaining[2..];
-                // SAFETY: `first` and `second` have been validated to form a correct 2-byte sequence.
-                return Some(unsafe { self.action.handle_2_byte(point) });
+                // SAFETY: `first` is in `C2..=DF` and `second` is in `80..=BF`
+                // (checked immediately above), which together form a valid 2-byte UTF-8 sequence.
+                return Some(unsafe { self.action.handle_2_byte(first, second) });
             }
             let third = self.remaining[2];
             if first < 0xF0 {
@@ -188,12 +181,14 @@ impl<'a, A: Utf8Action> Iterator for GenericUtf8Iter<'a, A> {
                 {
                     break;
                 }
-                let point = ((u32::from(first) & 0xF) << 12)
-                    | ((u32::from(second) & 0x3F) << 6)
-                    | (u32::from(third) & 0x3F);
                 self.remaining = &self.remaining[3..];
-                // SAFETY: `first`, `second`, and `third` have been validated to form a correct 3-byte sequence.
-                return Some(unsafe { self.action.handle_3_byte(point) });
+                // SAFETY: `first` is in `E0..=EF` (due to the check failure for `first < 0x80`
+                // and `in_inclusive_range8(first, 0xC2, 0xDF)`, and the `first < 0xF0` check here).
+                // The table-based check against `UTF8_DATA.table` validates that `first` and
+                // `second` form a valid prefix for a 3-byte sequence (including overlong
+                // and surrogate checks), and `(third >> 6) == 2` validates that `third`
+                // is a continuation byte (`80..=BF`).
+                return Some(unsafe { self.action.handle_3_byte(first, second, third) });
             }
             let fourth = self.remaining[3];
             if (u16::from(
@@ -204,13 +199,14 @@ impl<'a, A: Utf8Action> Iterator for GenericUtf8Iter<'a, A> {
             {
                 break;
             }
-            let point = ((u32::from(first) & 0x7) << 18)
-                | ((u32::from(second) & 0x3F) << 12)
-                | ((u32::from(third) & 0x3F) << 6)
-                | (u32::from(fourth) & 0x3F);
             self.remaining = &self.remaining[4..];
-            // SAFETY: `first`, `second`, `third`, and `fourth` have been validated to form a correct 4-byte sequence.
-            return Some(unsafe { self.action.handle_4_byte(point) });
+            // SAFETY: `first` is in `F0..=F4` (due to the `first < 0xF0` check failure and the
+            // table-based check's implicit lead byte range). The table-based check validates
+            // that `first` and `second` form a valid prefix for a 4-byte sequence (including
+            // overlong and out-of-range checks), `(third >> 6) == 2` (implied by the `0x202`
+            // mask/check) validates that `third` is a continuation byte, and `(fourth & 0xC0) == 0x80`
+            // (also implied by the `0x202` mask/check) validates that `fourth` is a continuation byte.
+            return Some(unsafe { self.action.handle_4_byte(first, second, third, fourth) });
         }
         self.next_fallback()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,11 @@
 mod cptrie;
 #[cfg(feature = "icu_collections")]
 mod cptrie_indices;
+mod generic;
 mod indices;
 mod report;
+
+pub use crate::generic::{GenericUtf8Iter, Utf8Action};
 
 #[cfg(feature = "icu_collections")]
 pub use crate::cptrie::Utf8CharsWithTrie;
@@ -101,172 +104,92 @@ pub(crate) fn in_inclusive_range8(i: u8, start: u8, end: u8) -> bool {
 /// potentially-invalid UTF-8. See the crate documentation.
 #[derive(Debug, Clone)]
 pub struct Utf8Chars<'a> {
-    remaining: &'a [u8],
+    inner: GenericUtf8Iter<'a, Utf8CharsAction>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Utf8CharsAction;
+
+impl Utf8Action for Utf8CharsAction {
+    type Output = char;
+
+    #[inline(always)]
+    unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output {
+        debug_assert!(ascii < 0x80);
+        char::from(ascii)
+    }
+
+    #[inline(always)]
+    unsafe fn handle_2_byte(&mut self, b1: u8, b2: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1` and `b2`
+        // form a valid 2-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+0080..=U+07FF`.
+        let point = ((u32::from(b1) & 0x1F) << 6) | (u32::from(b2) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        unsafe { char::from_u32_unchecked(point) }
+    }
+
+    #[inline(always)]
+    unsafe fn handle_3_byte(&mut self, b1: u8, b2: u8, b3: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, and `b3`
+        // form a valid 3-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+0800..=U+FFFF` (excluding surrogates).
+        let point = ((u32::from(b1) & 0xF) << 12)
+            | ((u32::from(b2) & 0x3F) << 6)
+            | (u32::from(b3) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        unsafe { char::from_u32_unchecked(point) }
+    }
+
+    #[inline(always)]
+    unsafe fn handle_4_byte(&mut self, b1: u8, b2: u8, b3: u8, b4: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, `b3`, and `b4`
+        // form a valid 4-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+10000..=U+10FFFF`.
+        let point = ((u32::from(b1) & 0x7) << 18)
+            | ((u32::from(b2) & 0x3F) << 12)
+            | ((u32::from(b3) & 0x3F) << 6)
+            | (u32::from(b4) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        unsafe { char::from_u32_unchecked(point) }
+    }
+
+    #[inline(always)]
+    fn handle_error(&mut self) -> Self::Output {
+        '\u{FFFD}'
+    }
 }
 
 impl<'a> Utf8Chars<'a> {
     #[inline(always)]
     /// Creates the iterator from a byte slice.
     pub fn new(bytes: &'a [u8]) -> Self {
-        Utf8Chars::<'a> { remaining: bytes }
+        Utf8Chars::<'a> {
+            inner: GenericUtf8Iter::new(bytes, Utf8CharsAction),
+        }
     }
 
     /// Views the current remaining data in the iterator as a subslice
     /// of the original slice.
     #[inline(always)]
     pub fn as_slice(&self) -> &'a [u8] {
-        self.remaining
-    }
-
-    #[inline(never)]
-    fn next_fallback(&mut self) -> Option<char> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let first = self.remaining[0];
-        if first < 0x80 {
-            self.remaining = &self.remaining[1..];
-            return Some(char::from(first));
-        }
-        if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
-            self.remaining = &self.remaining[1..];
-            return Some('\u{FFFD}');
-        }
-        let second = self.remaining[1];
-        let (lower_bound, upper_bound) = match first {
-            0xE0 => (0xA0, 0xBF),
-            0xED => (0x80, 0x9F),
-            0xF0 => (0x90, 0xBF),
-            0xF4 => (0x80, 0x8F),
-            _ => (0x80, 0xBF),
-        };
-        if !in_inclusive_range8(second, lower_bound, upper_bound) {
-            self.remaining = &self.remaining[1..];
-            return Some('\u{FFFD}');
-        }
-        if first < 0xE0 {
-            self.remaining = &self.remaining[2..];
-            let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
-            return Some(unsafe { char::from_u32_unchecked(point) });
-        }
-        if self.remaining.len() == 2 {
-            self.remaining = &self.remaining[2..];
-            return Some('\u{FFFD}');
-        }
-        let third = self.remaining[2];
-        if !in_inclusive_range8(third, 0x80, 0xBF) {
-            self.remaining = &self.remaining[2..];
-            return Some('\u{FFFD}');
-        }
-        if first < 0xF0 {
-            self.remaining = &self.remaining[3..];
-            let point = ((u32::from(first) & 0xF) << 12)
-                | ((u32::from(second) & 0x3F) << 6)
-                | (u32::from(third) & 0x3F);
-            return Some(unsafe { char::from_u32_unchecked(point) });
-        }
-        // At this point, we have a valid 3-byte prefix of a
-        // four-byte sequence that has to be incomplete, because
-        // otherwise `next()` would have succeeded.
-        self.remaining = &self.remaining[3..];
-        Some('\u{FFFD}')
+        self.inner.as_slice()
     }
 }
 
 impl<'a> Iterator for Utf8Chars<'a> {
     type Item = char;
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<char> {
-        // Not delegating directly to `ErrorReportingUtf8Chars` to avoid
-        // an extra branch in the common case based on a cursory inspection
-        // of generated code in a similar case. Be sure to inspect the
-        // generated code as inlined into an actual usage site carefully
-        // if attempting to consolidate the source code here.
-
-        // This loop is only broken out of as goto forward
-        #[allow(clippy::never_loop)]
-        loop {
-            if self.remaining.len() < 4 {
-                break;
-            }
-            let first = self.remaining[0];
-            if first < 0x80 {
-                self.remaining = &self.remaining[1..];
-                return Some(char::from(first));
-            }
-            let second = self.remaining[1];
-            if in_inclusive_range8(first, 0xC2, 0xDF) {
-                if !in_inclusive_range8(second, 0x80, 0xBF) {
-                    break;
-                }
-                let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
-                self.remaining = &self.remaining[2..];
-                return Some(unsafe { char::from_u32_unchecked(point) });
-            }
-            // This table-based formulation was benchmark-based in encoding_rs,
-            // but it hasn't been re-benchmarked in this iterator context.
-            let third = self.remaining[2];
-            if first < 0xF0 {
-                if ((UTF8_DATA.table[usize::from(second)]
-                    & UTF8_DATA.table[usize::from(first) + 0x80])
-                    | (third >> 6))
-                    != 2
-                {
-                    break;
-                }
-                let point = ((u32::from(first) & 0xF) << 12)
-                    | ((u32::from(second) & 0x3F) << 6)
-                    | (u32::from(third) & 0x3F);
-                self.remaining = &self.remaining[3..];
-                return Some(unsafe { char::from_u32_unchecked(point) });
-            }
-            let fourth = self.remaining[3];
-            if (u16::from(
-                UTF8_DATA.table[usize::from(second)] & UTF8_DATA.table[usize::from(first) + 0x80],
-            ) | u16::from(third >> 6)
-                | (u16::from(fourth & 0xC0) << 2))
-                != 0x202
-            {
-                break;
-            }
-            let point = ((u32::from(first) & 0x7) << 18)
-                | ((u32::from(second) & 0x3F) << 12)
-                | ((u32::from(third) & 0x3F) << 6)
-                | (u32::from(fourth) & 0x3F);
-            self.remaining = &self.remaining[4..];
-            return Some(unsafe { char::from_u32_unchecked(point) });
-        }
-        self.next_fallback()
+        self.inner.next()
     }
 }
 
 impl<'a> DoubleEndedIterator for Utf8Chars<'a> {
-    #[inline]
+    #[inline(always)]
     fn next_back(&mut self) -> Option<char> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let mut attempt = 1;
-        for b in self.remaining.iter().rev() {
-            if b & 0xC0 != 0x80 {
-                let (head, tail) = self.remaining.split_at(self.remaining.len() - attempt);
-                let mut inner = Utf8Chars::new(tail);
-                let candidate = inner.next();
-                if inner.as_slice().is_empty() {
-                    self.remaining = head;
-                    return candidate;
-                }
-                break;
-            }
-            if attempt == 4 {
-                break;
-            }
-            attempt += 1;
-        }
-
-        self.remaining = &self.remaining[..self.remaining.len() - 1];
-        Some('\u{FFFD}')
+        self.inner.next_back()
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -14,8 +14,7 @@
 // See the Licenses for the specific language governing permissions and
 // limitations under the Licenses.
 
-use crate::in_inclusive_range8;
-use crate::UTF8_DATA;
+use crate::{GenericUtf8Iter, Utf8Action};
 use core::fmt::Formatter;
 use core::iter::FusedIterator;
 
@@ -47,166 +46,92 @@ impl core::fmt::Display for Utf8CharsError {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ErrorReportingUtf8Chars<'a> {
-    remaining: &'a [u8],
+    inner: GenericUtf8Iter<'a, ErrorReportingUtf8CharsAction>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ErrorReportingUtf8CharsAction;
+
+impl Utf8Action for ErrorReportingUtf8CharsAction {
+    type Output = Result<char, Utf8CharsError>;
+
+    #[inline(always)]
+    unsafe fn handle_ascii(&mut self, ascii: u8) -> Self::Output {
+        debug_assert!(ascii < 0x80);
+        Ok(char::from(ascii))
+    }
+
+    #[inline(always)]
+    unsafe fn handle_2_byte(&mut self, b1: u8, b2: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1` and `b2`
+        // form a valid 2-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+0080..=U+07FF`.
+        let point = ((u32::from(b1) & 0x1F) << 6) | (u32::from(b2) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        Ok(unsafe { char::from_u32_unchecked(point) })
+    }
+
+    #[inline(always)]
+    unsafe fn handle_3_byte(&mut self, b1: u8, b2: u8, b3: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, and `b3`
+        // form a valid 3-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+0800..=U+FFFF` (excluding surrogates).
+        let point = ((u32::from(b1) & 0xF) << 12)
+            | ((u32::from(b2) & 0x3F) << 6)
+            | (u32::from(b3) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        Ok(unsafe { char::from_u32_unchecked(point) })
+    }
+
+    #[inline(always)]
+    unsafe fn handle_4_byte(&mut self, b1: u8, b2: u8, b3: u8, b4: u8) -> Self::Output {
+        // SAFETY: The `Utf8Action` trait contract guarantees that `b1`, `b2`, `b3`, and `b4`
+        // form a valid 4-byte UTF-8 sequence, which means the resulting scalar
+        // value is a valid code point in the range `U+10000..=U+10FFFF`.
+        let point = ((u32::from(b1) & 0x7) << 18)
+            | ((u32::from(b2) & 0x3F) << 12)
+            | ((u32::from(b3) & 0x3F) << 6)
+            | (u32::from(b4) & 0x3F);
+        debug_assert!(core::char::from_u32(point).is_some());
+        Ok(unsafe { char::from_u32_unchecked(point) })
+    }
+
+    #[inline(always)]
+    fn handle_error(&mut self) -> Self::Output {
+        Err(Utf8CharsError)
+    }
 }
 
 impl<'a> ErrorReportingUtf8Chars<'a> {
     #[inline(always)]
     /// Creates the iterator from a byte slice.
     pub fn new(bytes: &'a [u8]) -> Self {
-        ErrorReportingUtf8Chars::<'a> { remaining: bytes }
+        ErrorReportingUtf8Chars::<'a> {
+            inner: GenericUtf8Iter::new(bytes, ErrorReportingUtf8CharsAction),
+        }
     }
 
     /// Views the current remaining data in the iterator as a subslice
     /// of the original slice.
     #[inline(always)]
     pub fn as_slice(&self) -> &'a [u8] {
-        self.remaining
-    }
-
-    #[inline(never)]
-    fn next_fallback(&mut self) -> Option<Result<char, Utf8CharsError>> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let first = self.remaining[0];
-        if first < 0x80 {
-            self.remaining = &self.remaining[1..];
-            return Some(Ok(char::from(first)));
-        }
-        if !in_inclusive_range8(first, 0xC2, 0xF4) || self.remaining.len() == 1 {
-            self.remaining = &self.remaining[1..];
-            return Some(Err(Utf8CharsError));
-        }
-        let second = self.remaining[1];
-        let (lower_bound, upper_bound) = match first {
-            0xE0 => (0xA0, 0xBF),
-            0xED => (0x80, 0x9F),
-            0xF0 => (0x90, 0xBF),
-            0xF4 => (0x80, 0x8F),
-            _ => (0x80, 0xBF),
-        };
-        if !in_inclusive_range8(second, lower_bound, upper_bound) {
-            self.remaining = &self.remaining[1..];
-            return Some(Err(Utf8CharsError));
-        }
-        if first < 0xE0 {
-            self.remaining = &self.remaining[2..];
-            let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
-            return Some(Ok(unsafe { char::from_u32_unchecked(point) }));
-        }
-        if self.remaining.len() == 2 {
-            self.remaining = &self.remaining[2..];
-            return Some(Err(Utf8CharsError));
-        }
-        let third = self.remaining[2];
-        if !in_inclusive_range8(third, 0x80, 0xBF) {
-            self.remaining = &self.remaining[2..];
-            return Some(Err(Utf8CharsError));
-        }
-        if first < 0xF0 {
-            self.remaining = &self.remaining[3..];
-            let point = ((u32::from(first) & 0xF) << 12)
-                | ((u32::from(second) & 0x3F) << 6)
-                | (u32::from(third) & 0x3F);
-            return Some(Ok(unsafe { char::from_u32_unchecked(point) }));
-        }
-        // At this point, we have a valid 3-byte prefix of a
-        // four-byte sequence that has to be incomplete, because
-        // otherwise `next()` would have succeeded.
-        self.remaining = &self.remaining[3..];
-        Some(Err(Utf8CharsError))
+        self.inner.as_slice()
     }
 }
 
 impl<'a> Iterator for ErrorReportingUtf8Chars<'a> {
     type Item = Result<char, Utf8CharsError>;
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<Result<char, Utf8CharsError>> {
-        // This loop is only broken out of as goto forward
-        #[allow(clippy::never_loop)]
-        loop {
-            if self.remaining.len() < 4 {
-                break;
-            }
-            let first = self.remaining[0];
-            if first < 0x80 {
-                self.remaining = &self.remaining[1..];
-                return Some(Ok(char::from(first)));
-            }
-            let second = self.remaining[1];
-            if in_inclusive_range8(first, 0xC2, 0xDF) {
-                if !in_inclusive_range8(second, 0x80, 0xBF) {
-                    break;
-                }
-                let point = ((u32::from(first) & 0x1F) << 6) | (u32::from(second) & 0x3F);
-                self.remaining = &self.remaining[2..];
-                return Some(Ok(unsafe { char::from_u32_unchecked(point) }));
-            }
-            // This table-based formulation was benchmark-based in encoding_rs,
-            // but it hasn't been re-benchmarked in this iterator context.
-            let third = self.remaining[2];
-            if first < 0xF0 {
-                if ((UTF8_DATA.table[usize::from(second)]
-                    & UTF8_DATA.table[usize::from(first) + 0x80])
-                    | (third >> 6))
-                    != 2
-                {
-                    break;
-                }
-                let point = ((u32::from(first) & 0xF) << 12)
-                    | ((u32::from(second) & 0x3F) << 6)
-                    | (u32::from(third) & 0x3F);
-                self.remaining = &self.remaining[3..];
-                return Some(Ok(unsafe { char::from_u32_unchecked(point) }));
-            }
-            let fourth = self.remaining[3];
-            if (u16::from(
-                UTF8_DATA.table[usize::from(second)] & UTF8_DATA.table[usize::from(first) + 0x80],
-            ) | u16::from(third >> 6)
-                | (u16::from(fourth & 0xC0) << 2))
-                != 0x202
-            {
-                break;
-            }
-            let point = ((u32::from(first) & 0x7) << 18)
-                | ((u32::from(second) & 0x3F) << 12)
-                | ((u32::from(third) & 0x3F) << 6)
-                | (u32::from(fourth) & 0x3F);
-            self.remaining = &self.remaining[4..];
-            return Some(Ok(unsafe { char::from_u32_unchecked(point) }));
-        }
-        self.next_fallback()
+        self.inner.next()
     }
 }
 
 impl<'a> DoubleEndedIterator for ErrorReportingUtf8Chars<'a> {
-    #[inline]
+    #[inline(always)]
     fn next_back(&mut self) -> Option<Result<char, Utf8CharsError>> {
-        if self.remaining.is_empty() {
-            return None;
-        }
-        let mut attempt = 1;
-        for b in self.remaining.iter().rev() {
-            if b & 0xC0 != 0x80 {
-                let (head, tail) = self.remaining.split_at(self.remaining.len() - attempt);
-                let mut inner = ErrorReportingUtf8Chars::new(tail);
-                let candidate = inner.next();
-                if inner.as_slice().is_empty() {
-                    self.remaining = head;
-                    return candidate;
-                }
-                break;
-            }
-            if attempt == 4 {
-                break;
-            }
-            attempt += 1;
-        }
-
-        self.remaining = &self.remaining[..self.remaining.len() - 1];
-        Some(Err(Utf8CharsError))
+        self.inner.next_back()
     }
 }
 


### PR DESCRIPTION
This attempts to handle the `utf8_iter` side of https://github.com/unicode-org/icu4x/pull/7768#issuecomment-4128272042

This is purely demonstrative: The actual architecture we'd want here is where this code sans the CPT stuff lands on main, and then the CPT code in here can be private impls in icu_collections.

I like how this ended up, it also gave me an opportunity to document some of the invariants here.

I used Gemini 3.1 for a bunch of the repetitive stuff, especially since this code isn't what's going to land. It does seem to have done the right thing. I recommend copying out the code in generic.rs and doing the rest yourself, but feel free to do it some other way. I'm also happy to make a cleaner PR for `main` if you want me to but I might take time.